### PR TITLE
Moved the waitForTransactions back to outside the check for outstandi…

### DIFF
--- a/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TransactionReaper.java
+++ b/ArjunaCore/arjuna/classes/com/arjuna/ats/arjuna/coordinator/TransactionReaper.java
@@ -713,23 +713,23 @@ public class TransactionReaper
 
         synchronized (this) {
             _inShutdown = true;
+            /*
+                * If the caller does not want to wait for the normal transaction timeout
+                * periods to elapse before terminating, then we first start by enabling
+                * our time machine!
+                */
+
+            if (!waitForTransactions) {
+                _reaperElements.setAllTimeoutsToZero();
+                nextDynamicCheckTime.set(0);
+                notifyAll();
+            }
 
             /*
                 * Wait for all of the transactions to
                 * terminate normally.
                 */
             while (!_reaperElements.isEmpty()) {
-                /*
-                 * If the caller does not want to wait for the normal transaction timeout
-                 * periods to elapse before terminating, then we first start by enabling
-                 * our time machine!
-                 */
-
-                if (!waitForTransactions) {
-                    _reaperElements.setAllTimeoutsToZero();
-                    nextDynamicCheckTime.set(0);
-                    notifyAll();
-                }
                 
                 try {
                     this.wait(1000);


### PR DESCRIPTION
The justification to move this back would be due to the Javadoc of the shutdown method it is in:
```
    * Note, this method assumes that the transaction system has been
    * shutdown already so no new transactions can be created, or we
    * could be here for a long time!
```

Although that method is private, it is called from a public method terminate which has the following:
```
     * Note, this method assumes that the transaction system has been
     * shutdown already so no new transactions can be created, or we
     * could be here for a long time!
```